### PR TITLE
BUG FIX: fix self crash

### DIFF
--- a/crashwoodpecker/src/main/java/me/drakeet/library/ui/CrashListAdapter.java
+++ b/crashwoodpecker/src/main/java/me/drakeet/library/ui/CrashListAdapter.java
@@ -77,12 +77,17 @@ public class CrashListAdapter extends RecyclerView.Adapter<CrashListAdapter.View
             if (mPackageName != null && crash.contains(mPackageName)) {
                 holder.itemView.setSelected(true);
                 int indexOfC = crash.indexOf("(");
-                String atPackage = crash.substring(0, indexOfC);
-                SpannableStringBuilder builder = new SpannableStringBuilder(atPackage).append(
-                        StringStyleUtils.format(holder.title.getContext(),
-                                " " + crash.substring(indexOfC), R.style.LineTextAppearance));
-                CharSequence title = builder.subSequence(0, builder.length());
-                holder.title.setText(title);
+                if (indexOfC >= 0) {
+                    String atPackage = crash.substring(0, indexOfC);
+                    SpannableStringBuilder builder = new SpannableStringBuilder(atPackage).append(
+                            StringStyleUtils.format(holder.title.getContext(),
+                                    " " + crash.substring(indexOfC), R.style.LineTextAppearance));
+                    CharSequence title = builder.subSequence(0, builder.length());
+                    holder.title.setText(title);
+                } 
+                else {
+                    holder.title.setText(crash);
+                }
             }
             else {
                 holder.itemView.setSelected(false);


### PR DESCRIPTION
reason:
if an activity crash in onCreate(), the crash message is like this: "...Unable to start activity ComponentInfo{yourPackageName/yourPackageName.XxxActivity}:..", it contains your app package name, but has no '(', so the libaray crash.

how to test:
you can throw an RuntimeException in activity onCreate()