### PR TITLE
Remove dependency "com.android.support:appcompat-v7" 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.5.0'
+        classpath 'com.android.tools.build:gradle:2.1.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/crashwoodpecker/build.gradle
+++ b/crashwoodpecker/build.gradle
@@ -21,6 +21,5 @@ android {
 }
 
 dependencies {
-    compile 'com.android.support:appcompat-v7:22.2.1'
     compile 'com.android.support:recyclerview-v7:22.2.1'
 }

--- a/crashwoodpecker/src/main/java/me/drakeet/library/ui/CatchActivity.java
+++ b/crashwoodpecker/src/main/java/me/drakeet/library/ui/CatchActivity.java
@@ -25,10 +25,10 @@
 
 package me.drakeet.library.ui;
 
+import android.app.Activity;
 import android.content.Intent;
 import android.net.Uri;
 import android.os.Bundle;
-import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
 import android.view.Menu;
@@ -39,7 +39,7 @@ import me.drakeet.library.R;
  * Created by drakeet(http://drakeet.me)
  * Date: 8/31/15 22:42
  */
-public class CatchActivity extends AppCompatActivity {
+public class CatchActivity extends Activity {
 
     public final static String EXTRA_CRASH_LOGS = "extra_crash_logs";
     public final static String EXTRA_PACKAGE = "extra_package";

--- a/crashwoodpecker/src/main/res/layout/item_crash_cat.xml
+++ b/crashwoodpecker/src/main/res/layout/item_crash_cat.xml
@@ -45,6 +45,7 @@
         android:layout_weight="1"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:background="@color/item_crash"
         android:textColor="@color/trace_text"
         tools:text="123, 123"/>
 

--- a/crashwoodpecker/src/main/res/menu/menu_catch.xml
+++ b/crashwoodpecker/src/main/res/menu/menu_catch.xml
@@ -31,5 +31,5 @@
         android:id="@+id/action_settings"
         android:title="@string/action_settings"
         android:orderInCategory="100"
-        app:showAsAction="never"/>
+        android:showAsAction="never"/>
 </menu>

--- a/crashwoodpecker/src/main/res/values-v14/styles.xml
+++ b/crashwoodpecker/src/main/res/values-v14/styles.xml
@@ -26,16 +26,8 @@
 
 <resources>
 
-    <style name="Theme.Pecker" parent="Base.Theme.Pecker">
-        <item name="android:background">@color/windowBackground</item>
-    </style>
-
     <style name="Base.Theme.Pecker"
-        parent="android:Theme.Black">
-    </style>
-
-    <style name="LineTextAppearance">
-        <item name="android:textColor">@color/my_fault</item>
+        parent="android:Theme.Holo.Light.DarkActionBar">
     </style>
 
 </resources>

--- a/crashwoodpecker/src/main/res/values-v21/styles.xml
+++ b/crashwoodpecker/src/main/res/values-v21/styles.xml
@@ -26,16 +26,8 @@
 
 <resources>
 
-    <style name="Theme.Pecker" parent="Base.Theme.Pecker">
-        <item name="android:background">@color/windowBackground</item>
-    </style>
-
     <style name="Base.Theme.Pecker"
-        parent="android:Theme.Black">
-    </style>
-
-    <style name="LineTextAppearance">
-        <item name="android:textColor">@color/my_fault</item>
+        parent="android:Theme.Material.Light.DarkActionBar">
     </style>
 
 </resources>

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Aug 31 12:05:14 CST 2015
+#Tue May 17 17:17:10 CST 2016
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.10-all.zip


### PR DESCRIPTION
由于目前做的项目中还是用的之前的actionbarsherlock，导致引入crashwoodpecker的时候报错theme的一些属性名冲突，主要就是v7包和老的actionbarsherlock冲突了。参考了一下Leakcanary改成了不依赖appcompat-v7以适配一些老项目。