### PR TITLE
Refactor CrashWoodpecker

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/me.drakeet.library/crashwoodpecker/badge.svg?style=flat)](https://maven-badges.herokuapp.com/maven-central/me.drakeet.library/crashwoodpecker)
 
-A nice uncaught exception handler library likes Square's [LeakCanary](https://github.com/square/leakcanary). Support showing logs both on Logcat & Woodpecker.
+A nice and strong uncaught exception handler library, supports showing logs both on `Logcat` & **Woodpecker** and set a `AlertDialog` to help user to download a new stable application.
 
 ![screenshot.png](art/s2.png)
 
@@ -14,7 +14,7 @@ In your `build.gradle`:
 
 ```gradle
 dependencies {
-  compile 'me.drakeet.library:crashwoodpecker:2.0.0'
+  compile 'me.drakeet.library:crashwoodpecker:2.1.0'
 }
 ```
 
@@ -25,9 +25,12 @@ public class ExampleApplication extends Application {
 
   @Override public void onCreate() {
     super.onCreate();
-    CrashWoodpecker.flyTo(this);
-    // or add more highlight keys except the default package name:
-    // CrashWoodpecker.flyTo(this).withKeys("widget", "me.drakeet");
+    CrashWoodpecker.instance()
+        .withKeys("widget", "me.drakeet")
+        .setPatchMode(patchMode)
+        .setPatchDialogUrlToOpen("https://drakeet.me")
+        .setPassToOriginalDefaultHandler(true)
+        .flyTo(this);
   }
 }
 ```
@@ -49,30 +52,15 @@ And in your `AndroidManifest.xml` file:
 v1.3.0
 
 - Added `withKeys` for more highlight keys
-```java
-// add more highlight keys except the default package name:
-CrashWoodpecker.flyTo(this).withKeys("widget", "me.drakeet");
-```
-- Changed `setInterceptor` to return `CrashWoodpecker` itself
-- Updated android support libs to v24
 
-With multiple keys: packageName(default), "widget", "me.drakeet"
+eg. With multiple keys: packageName(default), "widget", "me.drakeet"
 
 <img src="art/s3.png" height=500 width=280/>
-
-v1.3.1
-
-- Added padding top & bottom to list and improved the selection program
-
-v1.3.2
-
-- Used application name to show in the crash page title
-
 
 ## TODO
 
 * Save logs and to reload.
-* Java doc and source archives.
+* Java doc.
 
 ## Thanks
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/me.drakeet.library/crashwoodpecker/badge.svg?style=flat)](https://maven-badges.herokuapp.com/maven-central/me.drakeet.library/crashwoodpecker)
 
-A nice and strong uncaught exception handler library, supports showing logs both on `Logcat` & **Woodpecker** and set a `AlertDialog` to help user to download a new stable application.
+A nice and strong uncaught exception handler library, supports showing logs both on `Logcat` & **Woodpecker** and set an `AlertDialog` to help user to download a new stable application.
 
 ![screenshot.png](art/s2.png)
 
@@ -61,6 +61,7 @@ eg. With multiple keys: packageName(default), "widget", "me.drakeet"
 
 * Save logs and to reload.
 * Java doc.
+* targetSdkVersion 23+
 
 ## Thanks
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -28,7 +28,7 @@ android {
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     testCompile 'junit:junit:4.12'
-    compile 'com.android.support:appcompat-v7:24.2.0'
+    compile 'com.android.support:appcompat-v7:24.2.1'
     compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     compile project(':crashwoodpecker')
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,8 +9,8 @@ android {
         applicationId "me.drakeet.demo"
         minSdkVersion 14
         targetSdkVersion 22
-        versionCode 132
-        versionName "1.3.2"
+        versionCode 210
+        versionName "2.1.0"
     }
 
     buildTypes {

--- a/app/src/main/kotlin/me/drakeet/demo/App.kt
+++ b/app/src/main/kotlin/me/drakeet/demo/App.kt
@@ -28,6 +28,7 @@ package me.drakeet.demo
 import android.app.ActivityManager
 import android.app.Application
 import android.content.Context
+import android.util.Log
 import me.drakeet.library.CrashWoodpecker
 import me.drakeet.library.PatchMode
 
@@ -46,10 +47,19 @@ class App : Application() {
             PatchMode.SHOW_DIALOG_TO_OPEN_URL
         }
         if (isMainProcess()) {
-            CrashWoodpecker.flyTo(this)
+            setupOriginalHandler()
+            CrashWoodpecker.instance()
                 .withKeys("widget", "me.drakeet")
                 .setPatchMode(patchMode)
                 .setPatchDialogUrlToOpen("https://drakeet.me")
+                .setPassToOriginalDefaultHandler(true)
+                .flyTo(this)
+        }
+    }
+
+    private fun setupOriginalHandler() {
+        Thread.setDefaultUncaughtExceptionHandler { thread, throwable ->
+            Log.e("CrashSample", "Default-UncaughtExceptionHandler", throwable)
         }
     }
 

--- a/crashwoodpecker/build.gradle
+++ b/crashwoodpecker/build.gradle
@@ -9,8 +9,8 @@ android {
     defaultConfig {
         minSdkVersion 9
         targetSdkVersion 22
-        versionCode 200
-        versionName "2.0.0"
+        versionCode 210
+        versionName "2.1.0"
     }
 
     buildTypes {

--- a/crashwoodpecker/gradle.properties
+++ b/crashwoodpecker/gradle.properties
@@ -46,8 +46,8 @@ POM_NAME=CrashWoodpecker
 POM_ARTIFACT_ID=crashwoodpecker
 POM_PACKAGING=aar
 
-VERSION_NAME=2.0.0
-VERSION_CODE=200
+VERSION_NAME=2.1.0
+VERSION_CODE=210
 GROUP=me.drakeet.library
 
 POM_DESCRIPTION=A nice uncaught exception handler library like Square's LeakCanary.

--- a/crashwoodpecker/gradle.properties
+++ b/crashwoodpecker/gradle.properties
@@ -50,7 +50,7 @@ VERSION_NAME=2.1.0
 VERSION_CODE=210
 GROUP=me.drakeet.library
 
-POM_DESCRIPTION=A nice uncaught exception handler library like Square's LeakCanary.
+POM_DESCRIPTION=A nice and strong uncaught exception handler library, supports showing logs both on Logcat & Woodpecker and set an AlertDialog to help user to download a new stable application.
 POM_URL=https://github.com/drakeet/CrashWoodpecker
 POM_SCM_URL=https://github.com/drakeet/CrashWoodpecker
 POM_SCM_CONNECTION=scm:git@github.com:drakeet/CrashWoodpecker.git

--- a/crashwoodpecker/src/main/AndroidManifest.xml
+++ b/crashwoodpecker/src/main/AndroidManifest.xml
@@ -40,7 +40,7 @@
             android:label="@string/cw_default_page_name"
             android:process=":woodpecker"
             android:taskAffinity="me.drakeet.library"
-            android:theme="@style/Theme.Dialog"/>
+            android:theme="@style/Theme.Pecker.Dialog"/>
     </application>
 
 </manifest>

--- a/crashwoodpecker/src/main/java/me/drakeet/library/CrashWoodpecker.java
+++ b/crashwoodpecker/src/main/java/me/drakeet/library/CrashWoodpecker.java
@@ -274,7 +274,7 @@ public class CrashWoodpecker implements UncaughtExceptionHandler {
     }
 
 
-    public CrashWoodpecker setPatchDialogMessage(@StringRes int messageResId) {
+    public CrashWoodpecker setPatchDialogMessage(int messageResId) {
         this.patchDialogMessage = applicationContext.getString(messageResId);
         return this;
     }

--- a/crashwoodpecker/src/main/java/me/drakeet/library/CrashWoodpecker.java
+++ b/crashwoodpecker/src/main/java/me/drakeet/library/CrashWoodpecker.java
@@ -33,7 +33,6 @@ import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
 import android.os.Build;
 import android.os.Environment;
-import android.support.annotation.StringRes;
 import android.util.Log;
 import java.io.File;
 import java.io.FileNotFoundException;

--- a/crashwoodpecker/src/main/java/me/drakeet/library/UncaughtExceptionInterceptor.java
+++ b/crashwoodpecker/src/main/java/me/drakeet/library/UncaughtExceptionInterceptor.java
@@ -1,0 +1,51 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 drakeet (drakeet.me@gmail.com)
+ * http://drakeet.me
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package me.drakeet.library;
+
+/**
+ * @author drakeet
+ */
+public interface UncaughtExceptionInterceptor {
+
+    /**
+     * Called before this uncaught exception be handled by {@link
+     * CrashWoodpecker}.
+     *
+     * @return true if intercepted, which means this event won't be handled
+     * by {@link CrashWoodpecker}.
+     */
+    boolean onBeforeHandlingException(Thread thread, Throwable throwable);
+
+    /**
+     * Called after this uncaught exception be handled by
+     * {@link CrashWoodpecker} (but before {@link CrashWoodpecker}'s
+     * parent).
+     *
+     * @return true if intercepted, which means this event won't be handled
+     * by {@link CrashWoodpecker}'s parent.
+     */
+    boolean onAfterHandlingException(Thread thread, Throwable throwable);
+}

--- a/crashwoodpecker/src/main/java/me/drakeet/library/UncaughtExceptionInterceptor.java
+++ b/crashwoodpecker/src/main/java/me/drakeet/library/UncaughtExceptionInterceptor.java
@@ -34,6 +34,8 @@ public interface UncaughtExceptionInterceptor {
      * Called before this uncaught exception be handled by {@link
      * CrashWoodpecker}.
      *
+     * @param thread the thread
+     * @param throwable the exception
      * @return true if intercepted, which means this event won't be handled
      * by {@link CrashWoodpecker}.
      */
@@ -44,6 +46,8 @@ public interface UncaughtExceptionInterceptor {
      * {@link CrashWoodpecker} (but before {@link CrashWoodpecker}'s
      * parent).
      *
+     * @param thread the thread
+     * @param throwable the exception
      * @return true if intercepted, which means this event won't be handled
      * by {@link CrashWoodpecker}'s parent.
      */

--- a/crashwoodpecker/src/main/java/me/drakeet/library/ui/CatchActivity.java
+++ b/crashwoodpecker/src/main/java/me/drakeet/library/ui/CatchActivity.java
@@ -87,6 +87,7 @@ public class CatchActivity extends Activity {
     }
 
 
+    @SuppressWarnings("deprecation")
     @Override public boolean onCreateOptionsMenu(Menu menu) {
         getMenuInflater().inflate(R.menu.menu_catch, menu);
         menu.add(Html.fromHtml("<font color='#ffffff'>drakeet</font>"))

--- a/crashwoodpecker/src/main/java/me/drakeet/library/ui/CrashListAdapter.java
+++ b/crashwoodpecker/src/main/java/me/drakeet/library/ui/CrashListAdapter.java
@@ -93,7 +93,7 @@ class CrashListAdapter extends RecyclerView.Adapter<CrashListAdapter.ViewHolder>
                         SpannableStringBuilder builder = new SpannableStringBuilder(
                             atPackage).append(
                             StringStyleUtils.format(holder.title.getContext(),
-                                " " + trace.substring(indexOfC), R.style.LineTextAppearance));
+                                " " + trace.substring(indexOfC), R.style.CWLineTextAppearance));
                         CharSequence title = builder.subSequence(0, builder.length());
                         holder.title.setText(title);
                     } else {

--- a/crashwoodpecker/src/main/java/me/drakeet/library/ui/CrashListAdapter.java
+++ b/crashwoodpecker/src/main/java/me/drakeet/library/ui/CrashListAdapter.java
@@ -37,8 +37,6 @@ import me.drakeet.library.R;
 import me.drakeet.library.Space;
 import me.drakeet.library.StringStyleUtils;
 
-import static me.drakeet.library.R.id.trace;
-
 /**
  * Created by drakeet(http://drakeet.me)
  * Date: 9/2/15 12:42
@@ -145,7 +143,7 @@ class CrashListAdapter extends RecyclerView.Adapter<CrashListAdapter.ViewHolder>
 
         ViewHolder(View itemView) {
             super(itemView);
-            title = (TextView) itemView.findViewById(trace);
+            title = (TextView) itemView.findViewById(R.id.trace);
             space = (Space) itemView.findViewById(R.id.space);
             itemView.setOnClickListener(this);
         }

--- a/crashwoodpecker/src/main/java/me/drakeet/library/ui/DialogActivity.java
+++ b/crashwoodpecker/src/main/java/me/drakeet/library/ui/DialogActivity.java
@@ -60,8 +60,13 @@ public class DialogActivity extends Activity {
         new AlertDialog.Builder(this)
             .setTitle(title)
             .setMessage(ultimateMessage)
-            .setCancelable(false)
+            .setCancelable(true)
             .setIcon(R.drawable.cw_ic_error)
+            .setOnCancelListener(new DialogInterface.OnCancelListener() {
+                @Override public void onCancel(DialogInterface dialog) {
+                    finish();
+                }
+            })
             .setNegativeButton(R.string.cw_action_download, new DialogInterface.OnClickListener() {
                 @Override public void onClick(DialogInterface dialog, int which) {
                     Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(url));

--- a/crashwoodpecker/src/main/res/values-v14/styles.xml
+++ b/crashwoodpecker/src/main/res/values-v14/styles.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
+<?xml version="1.0" encoding="utf-8"?><!--
   ~ The MIT License (MIT)
   ~
   ~ Copyright (c) 2015 drakeet (drakeet.me@gmail.com)
@@ -24,14 +23,13 @@
   ~ SOFTWARE.
   -->
 
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools"
+    tools:ignore="ResourceName">
 
     <style name="Base.Theme.Pecker"
-        parent="android:Theme.Holo.Light.DarkActionBar">
-    </style>
+        parent="android:Theme.Holo.Light.DarkActionBar"/>
 
-    <style name="Theme.NoTitleBar"
-        parent="android:Theme.Holo.NoActionBar">
-    </style>
+    <style name="Theme.Pecker.NoTitleBar"
+        parent="android:Theme.Holo.NoActionBar"/>
 
 </resources>

--- a/crashwoodpecker/src/main/res/values-v21/styles.xml
+++ b/crashwoodpecker/src/main/res/values-v21/styles.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
+<?xml version="1.0" encoding="utf-8"?><!--
   ~ The MIT License (MIT)
   ~
   ~ Copyright (c) 2015 drakeet (drakeet.me@gmail.com)
@@ -24,14 +23,13 @@
   ~ SOFTWARE.
   -->
 
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools"
+    tools:ignore="ResourceName">
 
     <style name="Base.Theme.Pecker"
-        parent="android:Theme.Material.Light.DarkActionBar">
-    </style>
+        parent="android:Theme.Material.Light.DarkActionBar"/>
 
-    <style name="Theme.NoTitleBar"
-        parent="android:Theme.Material.Light.NoActionBar">
-    </style>
+    <style name="Theme.Pecker.NoTitleBar"
+        parent="android:Theme.Material.Light.NoActionBar"/>
 
 </resources>

--- a/crashwoodpecker/src/main/res/values-zh/strings.xml
+++ b/crashwoodpecker/src/main/res/values-zh/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="cw_error_message">对不起！程序出现异常退出了。\n\n请点击 下载最新版 按钮获得最新稳定版，或者点击 重启 按钮进行重试。</string>
+    <string name="cw_error_message">对不起！程序出现异常退出了。\n\n请点击 下载最新版 按钮获得最新稳定版，或者点击 重启 按钮重启当前应用进行重试。</string>
     <string name="cw_action_download">下载最新版</string>
     <string name="cw_action_restart">重启</string>
     <string name="cw_action_settings">设置</string>

--- a/crashwoodpecker/src/main/res/values/strings.xml
+++ b/crashwoodpecker/src/main/res/values/strings.xml
@@ -24,6 +24,7 @@
   -->
 
 <resources>
+
     <string name="cw_default_page_name"
         translatable="false">Woodpecker</string>
 
@@ -34,7 +35,7 @@
 
     <string name="cw_action_restart">Restart</string>
     <string name="cw_action_download">Download</string>
-    <string name="cw_error_message">Sorry! There is something wrong with the App. \n\nPlease click <b>DOWNLOAD</b> to download a new stable version, or click RESTART to retry.</string>
+    <string name="cw_error_message">Sorry! There is something wrong with the App. \n\nPlease click <b>DOWNLOAD</b> to download a new stable version, or click RESTART to restart current App and retry.</string>
     <string name="cw_error_title">Error</string>
 
 </resources>

--- a/crashwoodpecker/src/main/res/values/styles.xml
+++ b/crashwoodpecker/src/main/res/values/styles.xml
@@ -23,7 +23,8 @@
   ~ SOFTWARE.
   -->
 
-<resources xmlns:tools="http://schemas.android.com/tools">
+<resources xmlns:tools="http://schemas.android.com/tools"
+    tools:ignore="ResourceName">
 
     <style name="Theme.Pecker"
         parent="Base.Theme.Pecker">
@@ -33,17 +34,17 @@
     <style name="Base.Theme.Pecker"
         parent="android:Theme.Black"/>
 
-    <style name="Theme.NoTitleBar"
+    <style name="Theme.Pecker.NoTitleBar"
         parent="android:Theme.NoTitleBar"/>
 
-    <style name="Theme.Dialog"
-        parent="Theme.NoTitleBar">
+    <style name="Theme.Pecker.Dialog"
+        parent="Theme.Pecker.NoTitleBar">
         <item name="android:windowBackground">@android:color/transparent</item>
         <item name="android:windowIsTranslucent">true</item>
         <item name="android:windowAnimationStyle">@android:style/Animation.Translucent</item>　
     </style>
 
-    <style name="LineTextAppearance">
+    <style name="CWLineTextAppearance">
         <item name="android:textColor">@color/cw_my_fault</item>
     </style>
 


### PR DESCRIPTION
- Changed `flyTo()` to be the end flow and activate the handler
- Changed `instance()` to be the entrance
- Added `getHandler(Context context)` -> `UncaughtExceptionHandler`
- Added `setPassToOriginalDefaultHandler` method
- Removed current thread `UncaughtExceptionHandler` logic
- Set patch dialog to be cancelable